### PR TITLE
Add post-latch registration step

### DIFF
--- a/.github/workflows/example-1.yml
+++ b/.github/workflows/example-1.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: '3.10'
       - id: latch
+        name: Install Latch
         uses: ./
       - run: echo latch version ${{ steps.latch.outputs.latch-version }}
+        name: Print latch version
         shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -135,7 +135,8 @@ runs:
           else
             echo "No .latch_report.tar.gz found! Continuing..."
           fi  
-          
+          # Turn this off so grep works
+          set +eo pipefail
           # Find the line in the log to start printing from.
           pattern="Unable to register workflow";
           result=$(grep "${pattern}" "register.log" || echo "");

--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - id: setup-ssh-config 
+    - id: setup-ssh-config
+      name: Setup SSH Config
       if: ${{ inputs.ssh-config == 'true' }}
       shell: bash
       run: |
@@ -66,18 +67,21 @@ runs:
         echo '    StrictHostKeyChecking no' >> ~/.ssh/config
         chmod 400 ~/.ssh/config
     - id: setup-workspace
+      name: Setup the Latch Workspace
       if: ${{ inputs.latch-workspace != '' }}
       shell: bash
       run: |
         mkdir -p ~/.latch
         echo -n "${{ inputs.latch-workspace }}" > ~/.latch/workspace
     - id: setup-token
+      name: Setup the Latch Token
       if: ${{ inputs.latch-token != '' }}
       shell: bash
       run: |
         mkdir -p ~/.latch
         echo -n "${{ inputs.latch-token }}" > ~/.latch/token
     - id: install-latch
+      name: Install Latch
       shell: bash
       run: |
         if [ "latest" == "${{ inputs.latch-version }}" ]; then
@@ -86,10 +90,12 @@ runs:
           python3 -m pip install latch==${{ inputs.latch-version }}
         fi
     - id: latch-version
+      name: Get the installed Latch version
       shell: bash
       run: |
         echo "latch-version=$(latch --version | cut -f 3 -d ' ')" >> $GITHUB_OUTPUT
     - id: latch-register
+      name: Register the Workflow on Latch
       if: ${{ inputs.register == 'true' }}
       shell: bash
       continue-on-error: true
@@ -107,6 +113,7 @@ runs:
           register_version=$(grep "Registering" register.log | tail -1 | cut -f 2 -d ' ' | cut -f 2 -d ':')
           echo "register-version=${register_version}" >> $GITHUB_OUTPUT
     - id: after-latch-register
+      name: Post-process Latch Workflow Registration
       if: ${{ inputs.register == 'true' }}
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -39,17 +39,21 @@ inputs:
     description: "Whether to automatically bump the version of the workflow each time register is called."
     required: false
     default: false
-
+  already-registered-do-not-fail:
+    description: "Whether the workflow should fail if the worfklow is already registered."
+    required: false
+    default: false
 
 outputs:
   latch-version:
     description: "The installed latch version."
     value: ${{ steps.latch-version.outputs.latch-version }}
   register-version:
-    description: "The workflow version that was registered"
+    description: "The workflow version that was registered.  Only set when 'inputs.register' is 'true'."
     value: ${{ steps.latch-register.outputs.register-version }}
-
-
+  already-registered:
+    description: "'true' if the workflow was already registered, 'false' otherwise.  Only set when 'inputs.register' is 'true'."
+    value: ${{ steps.after-latch-register.outputs.already-registered }}
 runs:
   using: "composite"
   steps:
@@ -88,6 +92,7 @@ runs:
     - id: latch-register
       if: ${{ inputs.register == 'true' }}
       shell: bash
+      continue-on-error: true
       run: |
           eval `ssh-agent -s`
           args="${{ inputs.register-pkg-root }}"
@@ -97,7 +102,63 @@ runs:
           if [ "${{ inputs.register-register-disable-auto-version }}" == "true" ]; then
             args="--register-disable-auto-version ${args}"
           fi
-          latch register --yes ${args} 2>&1 | tee register.log  
+          latch register --yes ${args} 2>&1 | tee register.log
+          # save registered version; this may not occur if the above register fails
           register_version=$(grep "Registering" register.log | tail -1 | cut -f 2 -d ' ' | cut -f 2 -d ':')
           echo "register-version=${register_version}" >> $GITHUB_OUTPUT
-          echo Registered version "${register_version}".
+    - id: after-latch-register
+      if: (${{ inputs.register == 'true' }})
+      shell: bash
+      run: |
+          # Deal with successful registration
+          if [[ "${{ steps.latch-register.outcome }}" == "success" ]]; then
+             echo Registered version ${{ steps.latch-register.outputs.latch-version }}
+             echo "already-registered=false" >> $GITHUB_OUTPUT
+             exit 0
+          fi
+      
+          # Deal with registration failure
+          spacer_line="------------------------------------------------------------"; 
+          already_registered="false"
+          
+          # Print environment information (e.g. installed latch version, OS, etc.)
+          if [ -f .latch-report.tag.gz ]; then
+            echo "Printing environment information:"
+            tar -Ozxvf .latch_report.tar.gz metadata.json 2>/dev/null
+          else
+            echo "No .latch_report.tag.gz found! Continuing..."
+          fi  
+          
+          # Find the line in the log to start printing from.
+          pattern="Unable to register workflow";
+          result=$(grep "${pattern}" "register.log" || echo "");
+          echo -e "${spacer_line}"
+          echo "Printing error traceback:"
+          if [[ "${result}" == "" ]]; then
+            # If no such line exists, then just print the last forty lines
+            tail -n 40 "register.log";
+            echo -e "${spacer_line}"
+            echo "Unknown error!"
+          else
+            # Print error information
+            sed -n "/${pattern}/"',$p' "register.log"
+            echo -e "${spacer_line}"
+            echo -n "Error: "
+            tail -4 "register.log" | head -1 | cut -f 2- -d ' '
+          fi
+          
+          # check if already registered
+          pattern="has already been registered."
+          result=$(grep "${pattern}" "register.log" || echo "");
+          if [[ "${result}" != "" ]]; then
+            already_registered="true"
+          fi
+          # save result
+          echo "already-registered=${already_registered}" >> $GITHUB_OUTPUT
+          # check if we should fail when the image was already registered
+          if [[ "${{ inputs.already-registered-do-not-fail }}" == "true" ]] && [[ "${already_registered}" == "true" ]]; then
+            exit 0;
+          fi
+          # fail otherwise
+          exit 1
+

--- a/action.yaml
+++ b/action.yaml
@@ -112,7 +112,7 @@ runs:
       run: |
           # Deal with successful registration
           if [[ "${{ steps.latch-register.outcome }}" == "success" ]]; then
-             echo Registered version ${{ steps.latch-register.outputs.latch-version }}
+             echo Registered version ${{ steps.latch-register.outputs.register-version }}
              echo "already-registered=false" >> $GITHUB_OUTPUT
              exit 0
           fi

--- a/action.yaml
+++ b/action.yaml
@@ -129,11 +129,11 @@ runs:
           already_registered="false"
           
           # Print environment information (e.g. installed latch version, OS, etc.)
-          if [ -f .latch-report.tag.gz ]; then
+          if [ -f .latch-report.tar.gz ]; then
             echo "Printing environment information:"
             tar -Ozxvf .latch_report.tar.gz metadata.json 2>/dev/null
           else
-            echo "No .latch_report.tag.gz found! Continuing..."
+            echo "No .latch_report.tar.gz found! Continuing..."
           fi  
           
           # Find the line in the log to start printing from.

--- a/action.yaml
+++ b/action.yaml
@@ -107,7 +107,7 @@ runs:
           register_version=$(grep "Registering" register.log | tail -1 | cut -f 2 -d ' ' | cut -f 2 -d ':')
           echo "register-version=${register_version}" >> $GITHUB_OUTPUT
     - id: after-latch-register
-      if: (${{ inputs.register == 'true' }})
+      if: ${{ inputs.register == 'true' }}
       shell: bash
       run: |
           # Deal with successful registration


### PR DESCRIPTION
Handle registration failure gracefully by printing information in an additional step.

Add a new output that flags if the workflow was already registered.

Add a new input option to not fail if the workflow was already registered.